### PR TITLE
Automatically accept host key

### DIFF
--- a/devstack.yaml
+++ b/devstack.yaml
@@ -26,7 +26,7 @@
       sudo: True
 
     - name: checkout devstack
-      git: "repo=git://{{ git_mirror }}/openstack-dev/devstack.git dest=/opt/stack/devstack version={{ devstack_branch }}"
+      git: "repo=git://{{ git_mirror }}/openstack-dev/devstack.git dest=/opt/stack/devstack version={{ devstack_branch }} accept_hostkey=yes"
 
     - name: local.conf
       template: src=templates/local.conf.j2 dest=/opt/stack/devstack/local.conf


### PR DESCRIPTION
When i run `vagrant up --provider=openstack` i have the following error on ansible provisionning

```
TASK: [checkout devstack] *****************************************************
failed: [default] => {"failed": true}
msg: git.openstack.org has an unknown hostkey. Set accept_hostkey to True or manually add the hostkey prior to running the git module

FATAL: all hosts have already failed -- aborting
```

Adding the option `accept_hostkey=yes` on git module fix the bug.
