### PR TITLE
Don't install solum dashboard if solum is disabled

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -44,6 +44,7 @@ $stack_sh_run = <<SCRIPT
 SCRIPT
 
 $solum_dashboard_install = <<SCRIPT
+   [ $(grep -e "^solum:" /vagrant/vars.yaml | cut -f2 -d" ") == 'False' ] && exit 0
    mkdir -p /opt/stack/solum-dashboard
    git clone git://github.com/stackforge/solum-dashboard.git /opt/stack/solum-dashboard
    sudo pip install -e /opt/stack/solum-dashboard


### PR DESCRIPTION
Even if i have `solum: False` in `vars.yml` vagrant provisioning install solum dashboard. As a consequence horizon is not working (500 error when trying to access to the login page).

```
[Thu Nov 13 23:39:35.442157 2014] [:error] [pid 17856:tid 139905715730176] [remote 82.230.242.143:35932]     import solumdashboard.assemblies.views as views
[Thu Nov 13 23:39:35.442168 2014] [:error] [pid 17856:tid 139905715730176] [remote 82.230.242.143:35932]   File "/opt/stack/solum-dashboard/solumdashboard/assemblies/views.py", line 19, in <module>
[Thu Nov 13 23:39:35.442185 2014] [:error] [pid 17856:tid 139905715730176] [remote 82.230.242.143:35932]     from solumdashboard.api.client import client as solumclient
[Thu Nov 13 23:39:35.442196 2014] [:error] [pid 17856:tid 139905715730176] [remote 82.230.242.143:35932]   File "/opt/stack/solum-dashboard/solumdashboard/api/client.py", line 18, in <module>
[Thu Nov 13 23:39:35.442214 2014] [:error] [pid 17856:tid 139905715730176] [remote 82.230.242.143:35932]     from solumclient import client as api_client
[Thu Nov 13 23:39:35.442240 2014] [:error] [pid 17856:tid 139905715730176] [remote 82.230.242.143:35932] ImportError: No module named solumclient
```

My fix is a bit dirty but this is the most straightforward. In my opinion, you should do the whole provisioning from ansible instead of running scripts from vagrant's shell provisionner. This refactoring is not a lot of work, it basically consist in calling shell scripts from the existing ansible playbook.
